### PR TITLE
Camera resize

### DIFF
--- a/Assets/Prefabs/GameManager.prefab
+++ b/Assets/Prefabs/GameManager.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 2791586991087175001}
   - component: {fileID: 2791586991087175002}
   - component: {fileID: 2791586991087175000}
+  - component: {fileID: 1482273345}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -29,7 +30,8 @@ Transform:
   m_LocalPosition: {x: 4.8822556, y: 3.2516828, z: 2.980941}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 3451433114369133375}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -77,3 +79,100 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!114 &1482273345
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2791586991087175003}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ee6302f5e1dc324a93e2d3852b83a6d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cameraBounds: {fileID: 3622560157437214247}
+--- !u!1 &8618134276506145464
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3451433114369133375}
+  - component: {fileID: 3622560157437214247}
+  m_Layer: 0
+  m_Name: CameraBounds
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3451433114369133375
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8618134276506145464}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2791586991087175001}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &3622560157437214247
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8618134276506145464}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 0bd8b2b8b3959984d9210a6443738ed5, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/Assets/Prefabs/GameManager.prefab
+++ b/Assets/Prefabs/GameManager.prefab
@@ -166,7 +166,7 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_Sprite: {fileID: 7482667652216324306, guid: 0bd8b2b8b3959984d9210a6443738ed5, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.043137256}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0

--- a/Assets/Scenes/TerminalTest.unity
+++ b/Assets/Scenes/TerminalTest.unity
@@ -533,7 +533,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 4.8, z: -10}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1130,15 +1130,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2791586991087175001, guid: e199549df538e3a498202bde506811a8, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 4.8822556
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2791586991087175001, guid: e199549df538e3a498202bde506811a8, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.2516828
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2791586991087175001, guid: e199549df538e3a498202bde506811a8, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 2.980941
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2791586991087175001, guid: e199549df538e3a498202bde506811a8, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/Scenes/TerminalTest.unity
+++ b/Assets/Scenes/TerminalTest.unity
@@ -1172,6 +1172,30 @@ PrefabInstance:
       propertyPath: m_Name
       value: GameManager
       objectReference: {fileID: 0}
+    - target: {fileID: 3451433114369133375, guid: e199549df538e3a498202bde506811a8, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 16.4065
+      objectReference: {fileID: 0}
+    - target: {fileID: 3451433114369133375, guid: e199549df538e3a498202bde506811a8, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 14.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 3622560157437214247, guid: e199549df538e3a498202bde506811a8, type: 3}
+      propertyPath: m_Color.a
+      value: 0.07058824
+      objectReference: {fileID: 0}
+    - target: {fileID: 3622560157437214247, guid: e199549df538e3a498202bde506811a8, type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3622560157437214247, guid: e199549df538e3a498202bde506811a8, type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3622560157437214247, guid: e199549df538e3a498202bde506811a8, type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e199549df538e3a498202bde506811a8, type: 3}
 --- !u!1001 &3629876657792536966

--- a/Assets/Scripts/Camera.meta
+++ b/Assets/Scripts/Camera.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6e5cec1a9d1bb454795e0929142a1711
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Camera/CameraResizer.cs
+++ b/Assets/Scripts/Camera/CameraResizer.cs
@@ -6,11 +6,22 @@ public class CameraResizer : MonoBehaviour
 {
     [SerializeField] SpriteRenderer cameraBounds;
 
+    private void Awake()
+    {
+        cameraBounds.color = new Color(0,0, 0, 0);
+    }
+
     private void Start()
     {
-        float screenRatio = (float)Screen.width / (float)Screen.height;
-        float boundsRatio = cameraBounds.bounds.size.x / cameraBounds.bounds.size.y;
 
+        Camera.main.orthographicSize = cameraBounds.bounds.size.x * Screen.height / Screen.width * 0.5f;
+
+        // Fancier alternative the video had for making sure the bounds are set regardless of orientation or aspect ratio
+        //    This feel not needed to me but leaving here just in case
+        //float screenRatio = (float)Screen.width / (float)Screen.height;
+        //float boundsRatio = cameraBounds.bounds.size.x / cameraBounds.bounds.size.y;
+
+        /*
         if (screenRatio >= boundsRatio)
         {
             Camera.main.orthographicSize = cameraBounds.bounds.size.y / 2;
@@ -20,5 +31,6 @@ public class CameraResizer : MonoBehaviour
             float difference = boundsRatio / screenRatio;
             Camera.main.orthographicSize = cameraBounds.bounds.size.y / 2 * difference;
         }
+        */
     }
 }

--- a/Assets/Scripts/Camera/CameraResizer.cs
+++ b/Assets/Scripts/Camera/CameraResizer.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CameraResizer : MonoBehaviour
+{
+    [SerializeField] SpriteRenderer cameraBounds;
+
+    private void Start()
+    {
+        float screenRatio = (float)Screen.width / (float)Screen.height;
+        float boundsRatio = cameraBounds.bounds.size.x / cameraBounds.bounds.size.y;
+
+        if (screenRatio >= boundsRatio)
+        {
+            Camera.main.orthographicSize = cameraBounds.bounds.size.y / 2;
+        }
+        else
+        {
+            float difference = boundsRatio / screenRatio;
+            Camera.main.orthographicSize = cameraBounds.bounds.size.y / 2 * difference;
+        }
+    }
+}

--- a/Assets/Scripts/Camera/CameraResizer.cs.meta
+++ b/Assets/Scripts/Camera/CameraResizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ee6302f5e1dc324a93e2d3852b83a6d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds the desired camera resizing support based off a reference sprite. Component is attached to the GameManager prefab. Adjust the size of the child CameraBounds object to change what size the camera is.